### PR TITLE
Constrain examples to max width

### DIFF
--- a/content/assets/css/fi.css
+++ b/content/assets/css/fi.css
@@ -47,3 +47,7 @@ pre.rdf {
   width: auto;
   overflow: scroll !important;
 }
+
+div#segment-content > div.container > div.row > div.inner-wrapper > div.col-12 > div[markdown="1"] {
+  max-width: 100%;
+}


### PR DESCRIPTION
Otherwise they expand to reveal the full width of the text content, which gives you a lot of horizontal scrolling, especially with examples with a lot of data on a single row.

A surrounding div has a hard-coded `style="display: inline-block"` definition which makes examples behave this way. No idea why it is there.