### PR TITLE
Change base for ImplementationGuide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Use it by stating
 `template = https://github.com/fhir-fi/ig-template-fhir-fi`
 
 in your `ig.ini` file.
+
+(See the [Finnish Base Profiles](https://github.com/fhir-fi/finnish-base-profiles/blob/a0d204fa0817b9e606263faabab3f40db6ad640c/ig.ini#L3) implementation guide for an example.)

--- a/config.json
+++ b/config.json
@@ -1,0 +1,373 @@
+{
+  "script": "scripts/ant.xml",
+	"otherScripts" : [],
+  "targets": {
+    "onLoad": "onLoad",
+    "onGenerate": "onGenerate"
+  },
+  "template-parameters": ["copyrightyear", "excludelogbinaryformat", "excludejson", "excludemap", "excludettl", "excludexml", "fmm-definition", "globals-in-artifacts", "releaselabel", "shownav"],
+  "_extraTemplates-documentation": "This array of objects identifies additional templates available for generation for different resource types",
+  "extraTemplates": [
+    {
+      "name": "mappings",
+      "description": "Mappings"
+    },
+    {
+      "name": "testing",
+      "description": "Testing"
+    },
+    {
+      "name": "examples",
+      "description": "Examples",
+      "isExamples": true
+    },
+    {
+      "name": "format",
+      "description": "FMT Representation"
+    },
+    {
+      "name": "profile-history",
+      "description": "Profile Change History",
+      "isHistory": true
+    },
+    {
+      "name": "change-history",
+      "description": "Resource Change History",
+      "isHistory": true
+    }
+  ],
+  "_formats-documentation": "Lists the formats in the order format-specific pages should be generated.  (Note that suppressed formats won't appear, even if listed here.)",
+  "formats": [
+    "xml",
+    "json",
+    "ttl"
+  ],
+  "_pre-process-documentation": "This array of objects indicates data being converted from existing files using scripts to support dependency checking when performing continuous builds",
+  "pre-process": [
+    {
+      "folder": "input/includes",
+      "relativePath": "_includes"
+    },
+    {
+      "folder": "fsh-generated/includes",
+      "relativePath": "_includes"
+    },
+    {
+      "folder": "input/data",
+      "relativePath": "_data"
+    },
+    {
+      "folder": "input/resourcedocs",
+      "relativePath": "_data"
+    },
+    {
+      "folder": "input/intro-notes",
+      "relativePath": "_includes",
+      "transform": "template/scripts/processPages.xslt"
+    },
+    {
+      "folder": "input/pagecontent",
+      "relativePath": "_includes",
+      "transform": "template/scripts/processPages.xslt"
+    },
+    {
+      "folder": "input/pages",
+      "relativePath": "_includes",
+      "transform": "template/scripts/processPages.xslt"
+    }
+  ],
+  "defaults": {
+    "_documentation": "this object contains the default publishing policy for different types. Anything not mentioned defaults to true",
+    "Any": {
+      "java": false,
+      "template-base": "template/layouts/layout-instance-base.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "list-types": "CodeSystem|ValueSet|NamingSystem",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "example": {
+      "java": false,
+      "template-base": "template/layouts/layout-instance-base.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "ImplementationGuide": {
+      "template-base": "",
+      "template-format": "",
+      "template-change-history":"",
+      "base": "index.html"
+    },
+    "StructureDefinition:extension": {
+      "template-base": "template/layouts/layout-ext.html",
+      "template-defns": "template/layouts/layout-profile-definitions.html",
+      "template-mappings": "template/layouts/layout-profile-mappings.html",
+      "template-testing": "template/layouts/layout-profile-testing.html",
+      "template-examples": "",
+      "template-profile-history": "template/layouts/layout-profile-history.html",
+      "template-format": "template/layouts/layout-profile-format.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "defns": "{{[type]}}-{{[id]}}-definitions.html",
+      "mappings": "{{[type]}}-{{[id]}}-mappings.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "examples": "{{[type]}}-{{[id]}}-examples.html",
+      "format": "{{[type]}}-{{[id]}}.profile.{{[fmt]}}.html",
+      "profile-history": "{{[type]}}-{{[id]}}.profile.history.html",
+      "template-change-history": ""
+    },
+    "StructureDefinition": {
+      "template-base": "template/layouts/layout-profile.html",
+      "template-defns": "template/layouts/layout-profile-definitions.html",
+      "template-mappings": "template/layouts/layout-profile-mappings.html",
+      "template-testing": "template/layouts/layout-profile-testing.html",
+      "template-examples": "template/layouts/layout-profile-examples.html",
+      "template-profile-history": "template/layouts/layout-profile-history.html",
+      "template-format": "template/layouts/layout-profile-format.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "defns": "{{[type]}}-{{[id]}}-definitions.html",
+      "mappings": "{{[type]}}-{{[id]}}-mappings.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "examples": "{{[type]}}-{{[id]}}-examples.html",
+      "format": "{{[type]}}-{{[id]}}.profile.{{[fmt]}}.html",
+      "profile-history": "{{[type]}}-{{[id]}}.profile.history.html",
+      "template-change-history": "",
+      "_comment": "this template-change-history is here to undo the definition in the Any settings"
+    },
+    "CodeSystem": {
+      "template-base": "template/layouts/layout-codesystem.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "ValueSet": {
+      "template-base": "template/layouts/layout-valueset.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "ActivityDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "ActorDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "CapabilityStatement": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "ConceptMap": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "ExampleScenario": {
+      "template-base": "template/layouts/layout-examplescenario.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "EventDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "GraphDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "Library": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "Measure": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "MeasureDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "MessageDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "NamingSystem": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "OperationDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "PlanDefinition": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "Questionnaire": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "Requirements": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "SearchParameter": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "StructureMap": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "TerminologyCapabilities": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "TestPlan" : {
+      "template-base" : "template/layouts/layout-canonical.html",
+      "template-format" : "template/layouts/layout-instance-format.html",
+      "template-testing" : "template/layouts/layout-canonical-testing.html",
+      "template-change-history" : "template/layouts/layout-changehistory.html",
+      "base" : "{{[type]}}-{{[id]}}.html",
+      "format" : "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing" : "{{[type]}}-{{[id]}}-testing.html",
+      "change-history" : "{{[type]}}-{{[id]}}.change.history.html"
+    },
+    "TestScript": {
+      "template-base": "template/layouts/layout-canonical.html",
+      "template-format": "template/layouts/layout-instance-format.html",
+      "template-testing": "template/layouts/layout-canonical-testing.html",
+      "template-change-history": "template/layouts/layout-changehistory.html",
+      "base": "{{[type]}}-{{[id]}}.html",
+      "format": "{{[type]}}-{{[id]}}.{{[fmt]}}.html",
+      "testing": "{{[type]}}-{{[id]}}-testing.html",
+      "change-history": "{{[type]}}-{{[id]}}.change.history.html"
+    }
+  }
+}
+

--- a/package-list.json
+++ b/package-list.json
@@ -2,7 +2,7 @@
   "package-id": "hl7.fi.fhir.template",
   "title": "HL7 Finland FHIR IG Template",
   "canonical": "https://github.com/fhir-fi/ig-template-fhir-fi",
-  "introduction": "Template for FHIR implementation guides published by HL7 Finland. Based on the hl7.affiliate.template.",
+  "introduction": "Template for FHIR implementation guides published by HL7 Finland. Based on [fhir.base.template](https://github.com/HL7/ig-template-base).",
   "list": [
     {
       "version": "current",

--- a/package-list.json
+++ b/package-list.json
@@ -12,11 +12,19 @@
       "current": true
     },
     {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "desc": "Include history templates",
       "path": "https://github.com/fhir-fi/ig-template-fhir-fi",
       "status": "release",
       "current": true,
+      "date": "20234-01-21"
+    },
+    {
+      "version": "1.0.2",
+      "desc": "Include history templates",
+      "path": "https://github.com/fhir-fi/ig-template-fhir-fi",
+      "status": "release",
+      "current": false,
       "date": "2023-07-11"
     },
     {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hl7.fi.fhir.template",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "type": "fhir.template",
   "license": "CC0-1.0",
   "description": "Template for FHIR implementation guides published by HL7 Finland.",


### PR DESCRIPTION
Import the config from fhir.base.template and change the `base` of the ImplementationGuide resource to refer to the index page of the implementation guide.

Fixes #7.